### PR TITLE
refactor: Dockerfile のマルチステージビルド化

### DIFF
--- a/go-server/Dockerfile
+++ b/go-server/Dockerfile
@@ -1,11 +1,17 @@
-FROM golang:1.23.4-alpine3.21
-
-WORKDIR /app
-
+# ビルドステージ（CGOの無効化、静的ビルド周り）
+FROM golang:1.23.4-alpine AS builder
+WORKDIR /build
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server ./cmd/main.go
 
-RUN go build -o server ./cmd/main.go
+# 実行ステージ
+FROM scratch
+COPY --from=builder /build/server /app/server
+
+# 非root実行
+COPY --from=alpine:latest /etc/passwd /etc/passwd
+USER nobody
 
 EXPOSE 8080
-
+WORKDIR /app
 CMD ["./server"]


### PR DESCRIPTION
- CGO無効化による静的ビルドで移植性を向上
- scratchイメージを使用して実行環境を最小化
- 非root実行でセキュリティを強化